### PR TITLE
Error al mostrar diálogo dentro de portal

### DIFF
--- a/src/rup.dialog.js
+++ b/src/rup.dialog.js
@@ -153,7 +153,7 @@
       //Ajuste para portales
       if ($.rup_utils.aplicatioInPortal()) {
         if ($(this).data("uiDialog").overlay !== null) {
-          $overlayEl = $(this).data("uiDialog").overlay.$el;
+          $overlayEl = $(this).data("uiDialog").overlay;
           $(".r01gContainer").append($overlayEl);
           $overlayEl.css("height", docHeight).css("width", docWidth);
 


### PR DESCRIPTION
El overlay no tiene la propiedad $el, de hecho si lo que se requiere es el $element de overlay no es neceario ya que se devuelve directamente...