### PR TITLE
Actualizar el separador de miles en la paginación de las tablas

### DIFF
--- a/i18n/rup.i18n_en.json
+++ b/i18n/rup.i18n_en.json
@@ -619,7 +619,7 @@
   "sInfoPostFix": "",
   "sSearch": "[EN]Buscar:",
   "sUrl": "",
-  "sInfoThousands": ".",
+  "sInfoThousands": ",",
   "sLoadingRecords": "[EN]Cargando...",
   "oPaginate": {
     "sFirst": "[EN]Primero",

--- a/i18n/rup.i18n_en.json
+++ b/i18n/rup.i18n_en.json
@@ -619,7 +619,7 @@
   "sInfoPostFix": "",
   "sSearch": "[EN]Buscar:",
   "sUrl": "",
-  "sInfoThousands": ",",
+  "sInfoThousands": ".",
   "sLoadingRecords": "[EN]Cargando...",
   "oPaginate": {
     "sFirst": "[EN]Primero",

--- a/i18n/rup.i18n_es.json
+++ b/i18n/rup.i18n_es.json
@@ -576,7 +576,7 @@
   "sInfoPostFix": "",
   "sSearch": "Buscar:",
   "sUrl": "",
-  "sInfoThousands": ",",
+  "sInfoThousands": ".",
   "sLoadingRecords": "Cargando...",
   "oPaginate": {
     "sFirst": "Primero",

--- a/i18n/rup.i18n_eu.json
+++ b/i18n/rup.i18n_eu.json
@@ -621,7 +621,7 @@
   "sInfoPostFix": "",
   "sSearch": "Aurkitu:",
   "sUrl": "",
-  "sInfoThousands": ",",
+  "sInfoThousands": ".",
   "sLoadingRecords": "Abiarazten...",
   "oPaginate": {
     "sFirst": "Lehena",

--- a/i18n/rup.i18n_fr.json
+++ b/i18n/rup.i18n_fr.json
@@ -618,7 +618,7 @@
   "sInfoPostFix": "",
   "sSearch": "[FR]Buscar:",
   "sUrl": "",
-  "sInfoThousands": ",",
+  "sInfoThousands": ".",
   "sLoadingRecords": "[FR]Cargando...",
   "oPaginate": {
     "sFirst": "[FR]Primero",

--- a/i18n/rup.i18n_fr.json
+++ b/i18n/rup.i18n_fr.json
@@ -618,7 +618,7 @@
   "sInfoPostFix": "",
   "sSearch": "[FR]Buscar:",
   "sUrl": "",
-  "sInfoThousands": ".",
+  "sInfoThousands": " ",
   "sLoadingRecords": "[FR]Cargando...",
   "oPaginate": {
     "sFirst": "[FR]Primero",


### PR DESCRIPTION
Kaixo,

Por defecto, en la paginación de las tablas el separador de miles está definido como una ',' :

![image](https://user-images.githubusercontent.com/2207608/172550507-94603740-01ea-4a1d-bd49-e182f5d23302.png)

Se cambian los json de rup para que el separador por defecto sea un '.' (como otros definidos) y como se hace en `com.ejie.x38.serialization.JsonBigDecimalSerializer`

![image](https://user-images.githubusercontent.com/2207608/172555110-42c497ad-8c50-4130-9d2d-a4ec59912e5f.png)

Un saludo.



