### PR TITLE
Actualización propiedad selectedAll en deselección.

### DIFF
--- a/src/rup_table/rup.table.multiSelect.js
+++ b/src/rup_table/rup.table.multiSelect.js
@@ -1186,6 +1186,7 @@ handler that will select the items using the API methods.
         $('#' + ctx.sTableId + ' tbody tr td.select-checkbox i.selected-pencil').remove();
 
         ctx.multiselection.lastSelectedIsRange = false;
+        ctx.multiselection.selectedAll = false;
     }
 
     /**
@@ -1428,9 +1429,7 @@ handler that will select the items using the API methods.
                     ctx.multiselection.lastSelectedId = '';
                 }
                 DataTable.Api().rupTable.selectPencil(ctx, -1);
-                if (ctx.multiselection.numSelected === 0) {
-                    ctx.multiselection.selectedAll = false;
-                }
+                ctx.multiselection.selectedAll = false;               
             }
             //Se mete el id para mantener el selectAll o no.
             if (id !== undefined && ctx.multiselection.deselectedIds.indexOf(id) < 0) {


### PR DESCRIPTION
Hola, en el caso de seleccionar todos los registros de una tabla multiselección la propiedad selectedAll se marca a true, pero no se está marcando a false en las siguientes casuísticas:

- Se deseleccionan los registros de una única página (sin deseleccionar el resto).
- Se deselecciona un elemento de cualquier página.

Se puede comprobar en la x21 en la tabla de ejemplo.

La PR intenta corregir estás casuisticas.

Gracias!